### PR TITLE
Update AlphaFold 3.0.1 definition to accommodate breaking changes in the upstream AF3  repository

### DIFF
--- a/AlphaFold/alphafold3-3.0.1.def
+++ b/AlphaFold/alphafold3-3.0.1.def
@@ -1,7 +1,9 @@
 Bootstrap: docker
-From: nvidia/cuda:12.6.0-base-ubuntu22.04
+From: nvidia/cuda:12.6.3-base-ubuntu24.04
 
 %environment
+    export UV_COMPILE_BYTECODE=1
+    export UV_PROJECT_ENVIRONMENT=/alphafold3_venv
     export PATH="/hmmer/bin:/alphafold3_venv/bin:/app/alphafold:$PATH"
     export XLA_FLAGS="--xla_gpu_enable_triton_gemm=false"
     export XLA_PYTHON_CLIENT_PREALLOCATE=true
@@ -9,50 +11,60 @@ From: nvidia/cuda:12.6.0-base-ubuntu22.04
 
 %post
     # Update and install basic dependencies
-    apt update --quiet
-    apt install --yes --quiet software-properties-common
-    apt install --yes --quiet git wget gcc g++ make zlib1g-dev zstd
+    DEBIAN_FRONTEND=noninteractive apt-get update --quiet
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --quiet \
+        python3.12 python3.12-dev \
+        git wget gcc g++ make zlib1g-dev zstd
 
-    # Install Python 3.11
-    add-apt-repository ppa:deadsnakes/ppa
-    DEBIAN_FRONTEND=noninteractive apt install --yes --quiet python3.11 python3-pip python3.11-venv python3.11-dev
-    
-    # Set up Python virtual environment
-    python3.11 -m venv /alphafold3_venv
-    . /alphafold3_venv/bin/activate
-    pip3 install --upgrade pip
+    # Install uv (version pinned for reproducibility)
+    wget -O - https://astral.sh/uv/0.9.24/install.sh | UV_INSTALL_DIR="/bin" sh
 
-    # Install HMMER
+    # Set up the virtual environment
+    UV_COMPILE_BYTECODE=1
+    UV_PROJECT_ENVIRONMENT=/alphafold3_venv
+    uv venv $UV_PROJECT_ENVIRONMENT
+
+    # Install HMMER from source with the --seq_limit patch applied
     mkdir /hmmer_build /hmmer
     wget http://eddylab.org/software/hmmer/hmmer-3.4.tar.gz --directory-prefix /hmmer_build
+    cd /hmmer_build && echo "ca70d94fd0cf271bd7063423aabb116d42de533117343a9b27a65c17ff06fbf3 hmmer-3.4.tar.gz" | sha256sum --check
     cd /hmmer_build && tar zxf hmmer-3.4.tar.gz && rm hmmer-3.4.tar.gz
+
+    # Apply the --seq_limit patch to HMMER
+    wget --directory-prefix /hmmer_build \
+        https://raw.githubusercontent.com/google-deepmind/alphafold3/751a4b8612d0d53de8f6e1830c8f726e873a55cf/docker/jackhmmer_seq_limit.patch
+    cd /hmmer_build && patch -p0 < jackhmmer_seq_limit.patch
+
     cd /hmmer_build/hmmer-3.4 && ./configure --prefix /hmmer
     cd /hmmer_build/hmmer-3.4 && make -j8
     cd /hmmer_build/hmmer-3.4 && make install
     cd /hmmer_build/hmmer-3.4/easel && make install
-    rm -R /hmmer_build
+    cd / && rm -R /hmmer_build 
 
-    # Set up AlphaFold3 directory
+    # Clone AlphaFold 3 source
     mkdir -p /app/alphafold
-
-%files
-    . /app/alphafold
-
-%post
-    # Continue installation after files are copied
+    git clone https://github.com/google-deepmind/alphafold3.git /app/alphafold
     cd /app/alphafold
-    . /alphafold3_venv/bin/activate
-    pip3 install -r dev-requirements.txt
-    pip3 install --no-deps .
-    build_data
 
-    # Add shebang and make the script executable
-    sed -i '1i#!/usr/bin/env python3' /app/alphafold/run_alphafold.py
-    chmod +x /app/alphafold/run_alphafold.py
+    export PATH="/hmmer/bin:/alphafold3_venv/bin:$PATH"
+    export UV_PROJECT_ENVIRONMENT=/alphafold3_venv
+
+    # Install the exact dependency tree using uv
+    # --frozen: do not update the lockfile during build
+    # --all-groups: install development/test dependencies defined in pyproject.toml
+    # --no-editable: install as a static package
+    UV_LINK_MODE=copy uv sync --frozen --all-groups --no-editable
+
+    # Build chemical components database (binary installed by uv sync)
+    uv run build_data
+
+    # Cleanup
+    uv cache prune
+    apt-get clean
 
 %runscript
-    . /alphafold3_venv/bin/activate
-    run_alphafold.py
+    cd /app/alphafold
+    UV_NO_CACHE=1 uv run --no-project python3 run_alphafold.py "$@"
 
 %labels
     Author DeepMind Technologies Limited

--- a/AlphaFold/lua/3.0.1.lua
+++ b/AlphaFold/lua/3.0.1.lua
@@ -16,10 +16,8 @@ whatis([==[Description: AlphaFold can predict protein structures with atomic acc
 whatis([==[Homepage: https://github.com/deepmind/alphafold]==])
 whatis([==[URL: https://github.com/deepmind/alphafold]==])
 
--- Load required dependencies
-load("Apptainer/1.2.5")
 
-local version = "3.0.0"
+local version = "3.0.1"
 local alphafold_root = "/opt/nesi/containers/AlphaFold"  -- Modify this path to where your container is stored
 
 -- Define the Apptainer binary path
@@ -31,7 +29,7 @@ setenv("ALPHAFOLD_CONTAINER", pathJoin(alphafold_root, "alphafold3-3.0.1.aimg"))
 
 -- Create a shell function for run_alphafold.py that automatically uses apptainer exec
 set_shell_function("run_alphafold.py", 
-     string.format('%s exec --nv %s/alphafold3-3.0.1.aimg run_alphafold.py "$@"', 
+     string.format('%s exec --nv %s python3 /app/alphafold/run_alphafold.py "$@"', 
              apptainer, 
              alphafold_root
      ))


### PR DESCRIPTION
Current .def file from Jan-2025 not  work anymore as AF3 changed  the repository structure recently and moved from pip-based to `uv` 
### Breaking change in upstream

The AlphaFold 3 repository removed `dev-requirements.txt` and migrated to a `uv`-managed project with `pyproject.toml` and `uv.lock`. The previous build workflow failed with:
```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'dev-requirements.txt'
```
### Main Changes

#### `alphafold3.def`

- **Base image** bumped from `nvidia/cuda:12.6.0-base-ubuntu22.04` to `nvidia/cuda:12.6.3-base-ubuntu24.04`. Ubuntu 24.04 ships Python 3.12 natively, removing the need for the deadsnakes PPA and manual venv setup.  **`uv` replaces pip** as the package manager. The build now uses
  `uv venv`, `uv sync --frozen --all-groups --no-editable`, and `uv run build_data`
  in line with the upstream Dockerfile.
- **`--seq_limit` patch** applied to HMMER prior to compilation, consistent with the upstream Dockerfile recommendation.
- **`UV_NO_CACHE=1`** added to `%runscript` to prevent uv attempting to create a cache directory in the user's home, which fails on HPC systems where `~/.cache/uv` may already exist or the home directory is read-only.
- 
#### `.lua` file 

- **`apptainer run` replaces the old shell function** — `run_alphafold.py` is no longer on the container's PATH and must be called explicitly as `python3 /app/alphafold/run_alphafold.py`.